### PR TITLE
Update linshare-upgrade-from-v5.1-to-v6.0.md

### DIFF
--- a/documentation/FR/upgrade/linshare-upgrade-from-v5.1-to-v6.0.md
+++ b/documentation/FR/upgrade/linshare-upgrade-from-v5.1-to-v6.0.md
@@ -68,6 +68,18 @@ Pour cette migration, il faut télécharger les fichiers suivants à partir de c
 
 <a name="backup">
 
+## Prérequis :
+</a>
+Afin d'éviter que les tâches lancées via l'interface d'administration durent beaucoup trop longtemps, il faut s'assurer que les indexes sont présents sur la base mongo.
+Pour les créer :
+
+```bash
+mongosh --host IP --port PORT
+use linshare;
+db.audit_log_entries.createIndex({"domain.uuid":1})
+db.audit_log_entries.createIndex({"actor.uuid":1})
+```
+
 ## Backups :
 
 </a>


### PR DESCRIPTION
Bonjour,
Petit retour d'expérience sur l'upgrade.
Nous avons lancé la tâches de migration complémentaires "upgrade 5.1 to 6.0" via webui admin.  Cette dernière à pris 15 jours (environ 35 000 comptes). Après vérification dans les logs mongo nous avions des logs type "COLLSCAN". 
En créant les indexes sur la base mongo, la tache s'est exécuté en 1h00. 
Bonne soirée.
Cordialement,
Timothé